### PR TITLE
Renamed $txt into $query

### DIFF
--- a/parser.php
+++ b/parser.php
@@ -898,7 +898,7 @@ class parser
 
     }
 
-    function dccParse($line, $vars, $txt)
+    function dccParse($line, $vars, $query)
     {
         $cVars = count($vars);
 


### PR DESCRIPTION
The bot wasn't able to process the upload correctly since it didn't reference the correct variable